### PR TITLE
Fixes #2 (Property '0' does not exist on type '{}')

### DIFF
--- a/src/components/WalletProviders.tsx
+++ b/src/components/WalletProviders.tsx
@@ -7,16 +7,18 @@ export const DiscoverWalletProviders = () => {
   const [userAccount, setUserAccount] = useState<string>('')
   const providers = useSyncProviders()
 
-  const handleConnect = async (providerWithInfo: EIP6963ProviderDetail) => {
-    try {
-      const accounts = await providerWithInfo.provider.request({ 
-        method: 'eth_requestAccounts' 
-      });
-
-      setSelectedWallet(providerWithInfo);
-      setUserAccount(accounts?.[0]);
-    } catch (error) {
-      console.error(error);
+  const handleConnect = async(providerWithInfo: EIP6963ProviderDetail)=> {
+    const accounts: string[] | undefined = await (
+      providerWithInfo.provider
+        .request({
+          method:'eth_requestAccounts'
+        })
+        .catch(console.error)
+      ) as string[] | undefined
+      
+    if(accounts?.[0]){
+      setSelectedWallet(providerWithInfo)
+      setUserAccount(accounts?.[0])
     }
   }
 

--- a/src/components/WalletProviders.tsx
+++ b/src/components/WalletProviders.tsx
@@ -7,16 +7,15 @@ export const DiscoverWalletProviders = () => {
   const [userAccount, setUserAccount] = useState<string>('')
   const providers = useSyncProviders()
 
-  const handleConnect = async(providerWithInfo: EIP6963ProviderDetail)=> {
-    const accounts: string[] | undefined = await (
-      providerWithInfo.provider
-        .request({
-          method:'eth_requestAccounts'
-        })
-        .catch(console.error)
-      ) as string[] | undefined
-      
-    if(accounts?.[0]){
+  const handleConnect = async (providerWithInfo: EIP6963ProviderDetail) => {
+    const accounts: string[] | undefined =
+      await (
+        providerWithInfo.provider
+          .request({ method: 'eth_requestAccounts' })
+          .catch(console.error)
+      ) as string[] | undefined;
+
+    if (accounts?.[0]) {
       setSelectedWallet(providerWithInfo)
       setUserAccount(accounts?.[0])
     }


### PR DESCRIPTION
"Element implicitly has an 'any' type because expression of type '0' can't be used to index type '{}'. Property '0' does not exist on type '{}'.", 

This occurs in TypeScript when we're trying to access an array element but TypeScript cannot infer the correct type of the array, possibly interpreting it as an empty object (`{}`) instead of an array.

To fix the error, we provided a type annotation for the accounts variable to avoid the implicit 'any' type.
To fix the error "Type 'unknown' is not assignable to type 'string[] | undefined'", we explicitly type the accounts variable as `string[] | undefined` when declaring it.

The problematic code:

```tsx
  const handleConnect = async(providerWithInfo: EIP6963ProviderDetail)=> {
    const accounts = await providerWithInfo.provider
      .request({method:'eth_requestAccounts'})
      .catch(console.error)
      
    if(accounts?.[0]){
      setSelectedWallet(providerWithInfo)
      setUserAccount(accounts?.[0])
    }
  }
```

Was updated to:

```tsx
  const handleConnect = async (providerWithInfo: EIP6963ProviderDetail) => {
    const accounts: string[] | undefined =
      await (
        providerWithInfo.provider
          .request({ method: 'eth_requestAccounts' })
          .catch(console.error)
      ) as string[] | undefined;

    if (accounts?.[0]) {
      setSelectedWallet(providerWithInfo)
      setUserAccount(accounts?.[0])
    }
  }
  ```


